### PR TITLE
Add callbacks for policy usage

### DIFF
--- a/lib/pundit/resource.rb
+++ b/lib/pundit/resource.rb
@@ -5,6 +5,8 @@ module Pundit
     extend ActiveSupport::Concern
 
     included do
+      define_jsonapi_resources_callbacks :policy_authorize
+
       before_save :authorize_create_or_update
       before_remove :authorize_destroy
     end
@@ -32,8 +34,10 @@ module Pundit
     protected
 
     def can(method)
-      context[:policy_used].call
-      policy.public_send(method)
+      run_callbacks :policy_authorize do
+        context[:policy_used].call
+        policy.public_send(method)
+      end
     end
 
     def current_user

--- a/spec/controllers/callbacks_spec.rb
+++ b/spec/controllers/callbacks_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe UsersController, type: :controller do
+  def do_request
+    delete :destroy, params_hash(id: User.create!.id)
+  end
+
+  def self.set_callback(klass, name, time, method)
+    before do
+      klass.set_callback(name, time, method)
+      unless klass.method_defined?(method)
+        allow_any_instance_of(klass).to receive(method)
+      end
+    end
+    after { klass.skip_callback(name, time, method) }
+  end
+
+  def self.let_temporary_exception_class(name)
+    let(name) { Class.new(StandardError) }
+    before { JSONAPI.configuration.exception_class_whitelist.push error }
+    after { JSONAPI.configuration.exception_class_whitelist.pop }
+  end
+
+  context "before authorizing" do
+    let_temporary_exception_class :error
+    set_callback UserResource, :policy_authorize, :before, :test
+
+    before do
+      # Raise an exception when the policy is used.
+      # This means that the after actions won't be called.
+      allow_any_instance_of(UserPolicy).to receive(:destroy?) { raise error }
+    end
+
+    it "calls before_policy_authorize callbacks" do
+      expect_any_instance_of(UserResource).to receive(:test)
+      expect { do_request }.to raise_error error
+    end
+  end
+
+  context "after authorizing" do
+    set_callback UserResource, :policy_authorize, :after, :test
+
+    before do
+      # Set an instance variable when the policy is used so it can be tested
+      # that after actions are run after and not before.
+      original = UserPolicy.instance_method(:destroy?)
+      allow_any_instance_of(UserPolicy).to receive(:destroy?) { |instance|
+        @called = true
+        original.bind(instance).call
+      }
+    end
+
+    it "calls after_policy_authorize callbacks" do
+      expect_any_instance_of(UserResource).to receive(:test) {
+        expect(@called).to be true
+      }
+
+      do_request
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -10,14 +10,6 @@ RSpec.describe UsersController, type: :controller do
 
   let(:body) { JSON.parse(response.body, symbolize_names: true) }
 
-  def params_hash(inner_hash)
-    if Rails.version < '5.0.0'
-      inner_hash
-    else
-      { params: inner_hash }
-    end
-  end
-
   describe "#index" do
     # Make sure there are multiple users in the database,
     # and select one at random that will feature in the random scope

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+Dir["#{__dir__}/support/types/**/*.rb"].each { |f| require f }
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/types/controller.rb
+++ b/spec/support/types/controller.rb
@@ -1,0 +1,9 @@
+RSpec.shared_context "controller specs", type: :controller do
+  def params_hash(inner_hash)
+    if Rails.version.split(?.).first.to_i < 5
+      inner_hash
+    else
+      { params: inner_hash }
+    end
+  end
+end


### PR DESCRIPTION
In an application I'm using pundit-resources in, I need to add an association to a record before it's authorized, or it won't be allowed. Adding callbacks around policy checking seems like someting that could come in handy in a few situations.
