### PR TITLE
Fix SyntaxError in resources.rb

### DIFF
--- a/lib/pundit/resource.rb
+++ b/lib/pundit/resource.rb
@@ -37,7 +37,7 @@ module Pundit
     end
 
     def current_user
-      context&.[](:current_user)
+      context[:current_user]
     end
 
     def policy


### PR DESCRIPTION
Before I made this change I was getting the following error:

```
SyntaxError: /Users/lynnhurley/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pundit-resources-1.0.0/lib/pundit/resource.rb:34: syntax error, unexp
ected '.'
      context&.[](:current_user)
```

With this change everything works as expected.
