### PR TITLE
Allow non-ActiveRecord to-one relationships

### DIFF
--- a/lib/pundit/resource.rb
+++ b/lib/pundit/resource.rb
@@ -58,16 +58,26 @@ module Pundit
     end
 
     def records_for(association_name, options={})
-      association_reflection = _model.class.reflect_on_association(association_name)
+      relationships = self.class._relationships.
+        values.
+        select { |r| r.relation_name(context: @context) == association_name }.
+        uniq(&:class)
 
-      if association_reflection.macro == :has_many
+      unless relationships.count == 1
+        raise "Can't infer relationship type for #{association_name}"
+      end
+
+      relationship = relationships.first
+
+      case relationship
+      when JSONAPI::Relationship::ToMany
         records = _model.public_send(association_name)
         policy_scope = Pundit.policy_scope!(
           context[:current_user],
           records
         )
         records.merge(policy_scope)
-      elsif [:has_one, :belongs_to].include?(association_reflection.macro)
+      when JSONAPI::Relationship::ToOne
         record = _model.public_send(association_name)
 
         # Don't rely on policy.show? being defined since it isn't used for

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,2 +1,5 @@
 class User < ApplicationRecord
+  def x_post
+    Post.find_or_create_by!(title: "Hello")
+  end
 end

--- a/spec/dummy/app/policies/post_policy.rb
+++ b/spec/dummy/app/policies/post_policy.rb
@@ -1,0 +1,25 @@
+class PostPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/spec/dummy/app/resources/post_resource.rb
+++ b/spec/dummy/app/resources/post_resource.rb
@@ -1,0 +1,3 @@
+class PostResource < JSONAPI::Resource
+  include Pundit::Resource
+end

--- a/spec/dummy/app/resources/user_resource.rb
+++ b/spec/dummy/app/resources/user_resource.rb
@@ -2,4 +2,9 @@ class UserResource < JSONAPI::Resource
   include Pundit::Resource
 
   attribute :created_at
+
+  # include relationship with and without relation_name:
+  # to check both cases are handled
+  has_one :x_post, class_name: "Post"
+  has_one :post, relation_name: :x_post, class_name: "Post"
 end

--- a/spec/dummy/db/migrate/20160720111317_create_posts.rb
+++ b/spec/dummy/db/migrate/20160720111317_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :posts do |t|
+      t.text :title
+      t.belongs_to :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160524135754) do
+ActiveRecord::Schema.define(version: 20160720111317) do
+
+  create_table "posts", force: :cascade do |t|
+    t.text     "title"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/spec/resources/user_resource_spec.rb
+++ b/spec/resources/user_resource_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe UserResource do
+
+  let(:model) { User.new }
+  let(:context) { Hash.new }
+
+  let(:resource) { described_class.new(model, context) }
+  subject { resource }
+
+  describe "to-one relationships" do
+    specify "can use non-ActiveRecord associations" do
+      expect(subject.post._model.title).to start_with "Hello"
+    end
+  end
+
+end


### PR DESCRIPTION
Previously, this raised an error because it tried to check the type of the relationship using ActiveRecord reflection, instead of looking at the already-defined relationship from the resource.
