### PR TITLE
Remove `&.` syntax for ruby < 2.3 compatability

### DIFF
--- a/lib/pundit/resource.rb
+++ b/lib/pundit/resource.rb
@@ -16,7 +16,7 @@ module Pundit
         warn_if_show_defined
 
         context = options[:context]
-        context[:policy_used]&.call
+        context[:policy_used].try(:call)
         Pundit.policy_scope!(context[:current_user], _model_class)
       end
 
@@ -35,13 +35,15 @@ module Pundit
 
     def can(method)
       run_callbacks :policy_authorize do
-        context[:policy_used]&.call
+        context[:policy_used].try(:call)
         policy.public_send(method)
       end
     end
 
     def current_user
-      context&.[](:current_user)
+      return unless context
+
+      context[:current_user]
     end
 
     def policy


### PR DESCRIPTION
Fixes #26.

@NDari I'm not sure if @barelyknown wants to merge this into master or if backwards compatibility is a concern for this gem, but this patch should allow you to run this gem on Ruby 2.2

If this does not get merged into master you can always include it in your gemfile with...

``` ruby
gem 'pundit-resources', git: 'https://github.com/breyno127/pundit-resources.git', branch: 'backwards-compatibility-patch'
```
