### PR TITLE
Upgrade jsonapi-resources dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'appraisal'
 
 # Dependencies for dummy application
 gem 'sqlite3'
-gem 'jsonapi-resources', '~> 0.8.0'
+gem 'jsonapi-resources', '~> 0.9.0'
 gem 'pundit'
 
 gemspec

--- a/pundit-resources.gemspec
+++ b/pundit-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "jsonapi-resources"
   spec.add_dependency "pundit"
-  spec.add_dependency "rails", ">= 4.2.1", "< 5.1"
+  spec.add_dependency "rails", ">= 4.2.1", "< 5.2"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Hi! Thank you for your work on this gem.

Is there anything to prevent compatibility with jsonapi-resources 0.9.0? I can't find anything obvious from the [release log](https://github.com/cerebris/jsonapi-resources/releases/tag/v0.9.0).