### PR TITLE
Allow rails 5.1

### DIFF
--- a/pundit-resources.gemspec
+++ b/pundit-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "jsonapi-resources"
   spec.add_dependency "pundit"
-  spec.add_dependency "rails", ">= 4.2.1", "< 5.1"
+  spec.add_dependency "rails", ">= 4.2.1", "< 5.2"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/pundit-resources.gemspec
+++ b/pundit-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "jsonapi-resources"
   spec.add_dependency "pundit"
-  spec.add_dependency "rails", ">= 4.2.1", "< 5.2"
+  spec.add_dependency "rails", ">= 4.2.1", "< 5.3"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I've been using my fork of pundit-resources with Rails 5.1 for several weeks now with no hiccups.