### PR TITLE
Allow rails 5.1 and 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
 rvm:
   - 2.3.0
+gemfile:
+  - gemfiles/rails_4.gemfile
+  - gemfiles/rails_5.gemfile
+  - gemfiles/rails_5.1.gemfile
+  - gemfiles/rails_5.2.gemfile
 before_install: gem install bundler -v 1.11.2

--- a/Appraisals
+++ b/Appraisals
@@ -5,3 +5,11 @@ end
 appraise "rails-5" do
   gem "rails", "~> 5.0"
 end
+
+appraise "rails-5.1" do
+  gem "rails", "~> 5.1"
+end
+
+appraise "rails-5.2" do
+  gem "rails", "~> 5.2"
+end

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -6,6 +6,6 @@ gem "appraisal"
 gem "sqlite3"
 gem "jsonapi-resources", "~> 0.8.0"
 gem "pundit"
-gem "rails", "~> 4.2"
+gem "rails", "~> 5.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -6,6 +6,6 @@ gem "appraisal"
 gem "sqlite3"
 gem "jsonapi-resources", "~> 0.8.0"
 gem "pundit"
-gem "rails", "~> 4.2"
+gem "rails", "~> 5.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "sqlite3"
-gem "jsonapi-resources", :github => "cerebris/jsonapi-resources"
+gem "jsonapi-resources", "~> 0.8.0"
 gem "pundit"
 gem "rails", "~> 5.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/pundit-resources.gemspec
+++ b/pundit-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "jsonapi-resources"
   spec.add_dependency "pundit"
-  spec.add_dependency "rails", ">= 4.2.1", "< 5.1"
+  spec.add_dependency "rails", ">= 4.2.1", "< 5.3"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
In addition to change the rails version range to `< 5.3` the PR adds appraisal gemfiles for rails 5.1 and 5.2 and updates travis.yml to use them.