### PR TITLE
Update to rails 5.2 and jsonapi-resources 0.9.10.

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,11 @@
 appraise "rails-4" do
   gem "rails", "~> 4.2"
+  gem "sqlite3", '~> 1.3.6'
+  gem "jsonapi-resources", "~> 0.9.10"
 end
 
 appraise "rails-5" do
-  gem "rails", "~> 5.0"
+  gem "rails", "~> 5.2"
+  gem "sqlite3", '~> 1.3.6'
+  gem "jsonapi-resources", "~> 0.9.10"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'appraisal'
 
 # Dependencies for dummy application
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.6'
 gem 'jsonapi-resources', '~> 0.8.0'
 gem 'pundit'
 

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -3,9 +3,9 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "sqlite3"
-gem "jsonapi-resources", :github => "cerebris/jsonapi-resources"
+gem "sqlite3", "~> 1.3.6"
+gem "jsonapi-resources", "~> 0.9.10"
 gem "pundit"
 gem "rails", "~> 4.2"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -3,9 +3,9 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "sqlite3"
-gem "jsonapi-resources", :github => "cerebris/jsonapi-resources"
+gem "sqlite3", "~> 1.3.6"
+gem "jsonapi-resources", "~> 0.9.10"
 gem "pundit"
-gem "rails", "~> 5.0"
+gem "rails", "~> 5.2"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/pundit-resources.gemspec
+++ b/pundit-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "jsonapi-resources"
   spec.add_dependency "pundit"
-  spec.add_dependency "rails", ">= 4.2.1", "< 5.1"
+  spec.add_dependency "rails", ">= 4.2.1", "< 6"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,6 +19,9 @@ module Dummy
     if ActiveRecord::Base.respond_to?(:belongs_to_required_by_default=)
       config.active_record.belongs_to_required_by_default = false
     end
+    if config.active_record.sqlite3.respond_to?(:represent_boolean_as_integer)
+      config.active_record.sqlite3.represent_boolean_as_integer = true
+    end
   end
 end
 


### PR DESCRIPTION
- Updated to Rails 5.2
- Update to jsonapi-resources 0.9.10
- Locked to sqlite3 version 1.3.x because 1.4 does not seem to work with Rails 5

All specs are passing in Rails 4.2 and 5.2. Please review.